### PR TITLE
change from password to token authentication; add output path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Export posters, backgrounds, banners, and theme songs from Plex.
 sudo python3 -m pip install -r requirements.txt
 ```
 
+## Dry run
+To dry run this script (you can even do it from a different machine with a different filestructure), try the `--output-path` option:
+```sh
+python3 plex-poster-exporter.py --output-path /home/me/test
+
+# ... go through prompts.
+# ... assets get saved to this location:
+# /home/me/test/your-data/path/to/Library/Movie (1999)/poster.jpg
+
+# ... instead of the real path of the data, as Plex sees it:
+# # /your-data/path/to/Library/Movie (1999)/poster.jpg
+```
+
 ## Usage
 ```
 python3 plex-poster-exporter.py --verbose
@@ -13,23 +26,23 @@ python3 plex-poster-exporter.py --verbose
 
 ## Advanced Usage
 ```
-python3 plex-poster-exporter.py --username "<EMAIL>" --password "<PASSWORD>" --server "<SERVER>" --library "<LIBRARY>" --assets "<ASSETS>" --overwrite --verbose
+python3 plex-poster-exporter.py --username "<EMAIL>" --token "<TOKEN>" --server "<SERVER>" --library "<LIBRARY>" --output-path "<OUTPUTPATH>" --assets "<ASSETS>" --overwrite --verbose
 ```
 
 ## Arguments
 
 All arguments are optional. If one is required and it is not provided, the script will ask you to enter it.
 
-| Option          | Description                                                                    | Default       |  
-| --------------- | ------------------------------------------------------------------------------ | ------------- |  
-| --username      | The username for Plex.                                                         |               |  
-| --password      | The password for Plex.                                                         |               |  
-| --server        | The Plex server name.                                                          |               |  
-| --library       | The Plex library name.                                                         |               |  
-| --assets        | Which assets should be exported? (all, posters, backgrounds, banners, themes)  | all           |  
-| --overwrite     | Overwrite existing assets?                                                     | False         |  
-| --verbose       | Show extra information?                                                        | False         |  
-| --help          | Show the help message and exit.                                                |               |  
+| Option          | Description                                                                                         | Default       |  
+| --------------- | --------------------------------------------------------------------------------------------------- | ------------- |  
+| --username      | The username for Plex.                                                                              |               |  
+| --server        | The Plex server name.                                                                               |               |  
+| --library       | The Plex library name.                                                                              |               |  
+| --output-path   | The base output path; change to export assets in directory structure that mirrors your library.     | '/'           |  
+| --assets        | Which assets should be exported? (all, posters, backgrounds, banners, themes)                       | all           |  
+| --overwrite     | Overwrite existing assets?                                                                          | False         |  
+| --verbose       | Show extra information?                                                                             | False         |  
+| --help          | Show the help message and exit.                                                                     |               |  
 
 ## Notes
 


### PR DESCRIPTION
fixes #1

# changes
:twisted_rightwards_arrows: changed password auth to token auth
:open_file_folder: added `--output-path` option - great for dry runs. even works on a different machine.

# commentary
- modified the script to make it usable for me since password alone don't work with 2FA.
  - is there still interest in maintaining the password functionality? i've only seen plex token auth in other projects.
- i probably could have made these two different pull requests. my bad. happy to split them up, but figured someone else might find it useful either way.